### PR TITLE
Trim prompt to remove trailing space

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -223,6 +223,7 @@ prompt :: [H.Html] -> H.Html
 prompt parts = (H.div ! A.class_ "prompt") (go parts)
   where
     go [] = mempty
+    go [x] = x
     go (x:xs) = x <> " " <> go xs
 
 nowrap :: (H.Html -> H.Html) -> H.Html -> H.Html


### PR DESCRIPTION
This change removes trailing space from prompt elements
to make the selection looks better.