### PR TITLE
Use nix develop instead of nix-shell

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -272,7 +272,7 @@ topicSystem =
         ":"
       snippet do
         prompt [ "git", "clone", "https://github.com/alpmestan/" <> H.wbr <> "ghc.nix" ]
-        prompt [ "nix-shell ghc.nix" ]
+        prompt [ "nix develop ghc.nix" ]
       H.p do
         "This will install "
         H.code "alex" <> ", "


### PR DESCRIPTION
nix-shell produces:

```
nix-shell ghc.nix
error: nix-shell requires a single derivation
Try 'nix-shell --help' for more information.
```

presumably due to the flake,
I think it's safe to use flakes by default these days however.