### PR TITLE
Fix the nix-shell invocation

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -272,7 +272,7 @@ topicSystem =
         ":"
       snippet do
         prompt [ "git", "clone", "https://github.com/alpmestan/" <> H.wbr <> "ghc.nix" ]
-        prompt [ "nix-shell ghc.nix" ]
+        prompt [ "nix-shell ghc.nix/shell.nix" ]
       H.p do
         "This will install "
         H.code "alex" <> ", "


### PR DESCRIPTION
See also #16 - I'm not against switching to `nix develop`, but this is a simpler fix in the short term (no need to teach people how to enable flakes etc.).