### PR TITLE
Upgrade terraform and aws provider to the latest possible versions

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -3,5 +3,8 @@ The state is stored in an aws bucket on our account. Don't forget to set AWS_PRO
 
 ```bash
 export AWS_PROFILE=srk-prod
-nix-shell --run "terraform init && terraform apply"
+nix develop ../.#tf
+terraform init
+terraform plan
+terraform apply
 ```

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -24,24 +24,6 @@ variable "root_domain_name" {
 resource "aws_s3_bucket" "www" {
   // Our bucket's name is going to be the same as our site's domain name.
   bucket = "${var.root_domain_name}-prod"
-  // We also need to create a policy that allows anyone to view the content.
-  // This is basically duplicating what we did in the ACL but it's required by
-  // AWS. This post: http://amzn.to/2Fa04ul explains why.
-  policy = <<POLICY
-{
-  "Version":"2012-10-17",
-  "Statement":[
-    {
-      "Sid":"AddPerm",
-      "Effect":"Allow",
-      "Principal": "*",
-      "Action":["s3:GetObject"],
-      "Resource":["arn:aws:s3:::${var.root_domain_name}-prod/*"]
-    }
-  ]
-}
-POLICY
-
 }
 
 resource "aws_s3_bucket_acl" "example" {
@@ -68,6 +50,27 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "www" {
       sse_algorithm = "AES256"
     }
   }
+}
+
+resource "aws_s3_bucket_policy" "www_allow_access" {
+  bucket = aws_s3_bucket.www.id
+  // We also need to create a policy that allows anyone to view the content.
+  // This is basically duplicating what we did in the ACL but it's required by
+  // AWS. This post: http://amzn.to/2Fa04ul explains why.
+  policy = <<POLICY
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid":"AddPerm",
+      "Effect":"Allow",
+      "Principal": "*",
+      "Action":["s3:GetObject"],
+      "Resource":["arn:aws:s3:::${var.root_domain_name}-prod/*"]
+    }
+  ]
+}
+POLICY
 }
 
 resource "aws_acm_certificate" "cert" {

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -235,7 +235,7 @@ output "AWS_ACCESS_KEY_ID" {
   value = aws_iam_access_key.deployer.id
 }
 output "AWS_SECRET_ACCESS_KEY" {
-  value = aws_iam_access_key.deployer.secret
+  value = nonsensitive(aws_iam_access_key.deployer.secret)
 }
 output "CDN_DISTRIBUTION_ID" {
   value = aws_cloudfront_distribution.www_distribution.id

--- a/deployment/shell.nix
+++ b/deployment/shell.nix
@@ -1,2 +1,0 @@
-{ pkgs ? import <nixpkgs> { } }:
-pkgs.mkShell { buildInputs = [ (pkgs.terraform.withPlugins (p: [ p.aws ])) ]; }

--- a/deployment/versions.tf
+++ b/deployment/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/deployment/versions.tf
+++ b/deployment/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "= 3.76.0"
+      version = "= 4.67.0"
     }
   }
 }

--- a/deployment/versions.tf
+++ b/deployment/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.5.7"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/deployment/versions.tf
+++ b/deployment/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "= 4.67.0"
+      version = "= 5.19.0"
     }
   }
 }

--- a/deployment/versions.tf
+++ b/deployment/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "= 3.27.0"
+      version = "= 3.76.0"
     }
   }
 }

--- a/deployment/versions.tf
+++ b/deployment/versions.tf
@@ -1,4 +1,10 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "= 3.27.0"
+    }
+  }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689844446,
-        "narHash": "sha256-ud/6XYWbXFAJuTTApWyYlFtlc54NAxChS1T9Ns+qT7M=",
+        "lastModified": 1695806987,
+        "narHash": "sha256-fX5kGs66NZIxCMcpAGIpxuftajHL8Hil1vjHmjjl118=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2d82894fa1e2d23a22f40275a78bfbb09b92ffde",
+        "rev": "f3dab3509afca932f3f4fd0908957709bb1c1f57",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -33,5 +33,11 @@
           haskellPackages.cabal-install
         ];
       };
+
+      devShells.${system}.tf = pkgs.mkShell {
+        buildInputs = [
+          nixpkgs.legacyPackages.${system}.terraform
+        ];
+      };
     };
 }


### PR DESCRIPTION
Problem: we would like to reduce technical debt, hence use latest versions from tf and aws provider

Solution: upgrade tf to 1.5.7, aws provider to 5.19.0, use nix develop instead of nix-shell