### PR TITLE
Fix a few usability issues

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -238,7 +238,7 @@ topicCode =
       H.p do
         "GHC has its own "
         H.a "GitLab instance" ! A.href (ref RefGitLab)
-        ". You can sign in with your GitHub account."
+        "."
       snippet do
         prompt
           [ "git", "clone", nowrap H.span "--recurse-submodules",

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -332,7 +332,6 @@ topicBuildingDocs =
       snippet do
         prompt
           [ "hadrian/build", "-j",
-            nowrap H.span "--flavour=Quick",
             nowrap H.span "--freeze1",
             nowrap H.span "docs --docs=no-sphinx-pdfs" ]
       H.p "The generated HTML documentation is saved at:"
@@ -352,7 +351,6 @@ topicTesting =
       snippet do
         prompt
           [ "hadrian/build", "-j",
-            nowrap H.span "--flavour=Quick",
             nowrap H.span "--freeze1",
             "test",
             nowrap H.span "--only=\"T1 T2 T3\"" ]
@@ -386,6 +384,7 @@ topicDebugging =
         prompt
           [ "hadrian/build", "-j",
             nowrap H.span "--flavour=Devel2" ]
+      H.p "Note that some tests may not pass in this configuration."
     topicStyle = do pure()
 
 topicCommunication :: Topic

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -289,13 +289,11 @@ topicBuild =
         prompt ["./boot && ./configure"]
         prompt ["cabal", "v2-update"]
         prompt
-          [ "hadrian/build", "-j",
-            nowrap H.span "--flavour=Quick" ]
+          [ "hadrian/build", "-j" ]
       H.p ("Quick " <> H.code "stage2" <> " rebuild:")
       snippet do
         prompt
           [ "hadrian/build", "-j",
-            nowrap H.span "--flavour=Quick",
             nowrap H.span "--freeze1" ]
     topicStyle = do pure()
 


### PR DESCRIPTION
Use of the `Quick` flavour is not recommended for new users as it may not pass the testsuite.

Sadly `gitlab.haskell.org` no longer supports OAuth via GitHub due to on-going spam pressure.